### PR TITLE
Set sticky header nav bar

### DIFF
--- a/src/modules/Header/styles.css
+++ b/src/modules/Header/styles.css
@@ -1,5 +1,9 @@
 header {
   display: grid;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 header .bottom {
@@ -43,7 +47,7 @@ header nav div i:hover {
   color: rgb(0, 0, 0);
 }
 
-@media (max-width: 370px) {
+@media (max-width: 800px) {
   header .top {
     grid-template-columns: 1fr;
   }
@@ -71,4 +75,7 @@ header nav div i:hover {
     padding: 10px 0;
     z-index: 1;
   }
+
 }
+
+


### PR DESCRIPTION
Solves issue #24 

Plus, mediaquery was set to @media (max-width: 800px) 

It was breaking at 370px (iPhone8+ for instance)
![captura de pantalla 2018-11-16 a la s 11 20 42 p m](https://user-images.githubusercontent.com/30706016/48656718-f49da980-e9f6-11e8-84b8-eb6c6f51fe46.png)

Final result,
![captura de pantalla 2018-11-16 a la s 11 21 29 p m](https://user-images.githubusercontent.com/30706016/48656726-0e3ef100-e9f7-11e8-8707-09d78eed3039.png)
