### PR TITLE
Update Slack link

### DIFF
--- a/src/components/Header.html
+++ b/src/components/Header.html
@@ -15,7 +15,7 @@
 		<a class="header-icon header-order-4" target="_blank" href="https://github.com/barranquillajs"><svg class="icon icon-github">
 				<use xlink:href="#icon-github"></use>
 			</svg></a>
-		<a class="header-icon header-order-5" target="_blank" href="https://barranquillajs.slack.com/join/shared_invite/enQtNDI1OTYwOTE2MjQwLTJhYWIzOGJhZDQ3NDljYmMyZjNiMzUwYWM0ZGMwYTliMWRhYmQ2ZjVhODM4MjE2OTg4YTEwYTQzMjAzMzA1Mzc"><svg
+		<a class="header-icon header-order-5" target="_blank" href="https://join.slack.com/t/barranquillajs/shared_invite/zt-1dw9jhx0h-vlvgZCadLWW7U~odMgd1tA"><svg
 			 class="icon icon-slack">
 				<use xlink:href="#icon-slack"></use>
 			</svg></a>

--- a/src/components/Header.html
+++ b/src/components/Header.html
@@ -15,7 +15,7 @@
 		<a class="header-icon header-order-4" target="_blank" href="https://github.com/barranquillajs"><svg class="icon icon-github">
 				<use xlink:href="#icon-github"></use>
 			</svg></a>
-		<a class="header-icon header-order-5" target="_blank" href="https://join.slack.com/t/barranquillajs/shared_invite/zt-1dw9jhx0h-vlvgZCadLWW7U~odMgd1tA"><svg
+		<a class="header-icon header-order-5" target="_blank" href="https://t.co/3PiJSDDkIo"><svg
 			 class="icon icon-slack">
 				<use xlink:href="#icon-slack"></use>
 			</svg></a>


### PR DESCRIPTION
Updating slack invitation link, because the one in the page is currently broken.

## Screenshot

<img width="1029" alt="Screen Shot 2022-08-04 at 12 14 30 PM" src="https://user-images.githubusercontent.com/232293/182911169-7168d620-237a-42c4-af04-f34c008d0012.png">
